### PR TITLE
Compatibility to dnsdist 1.2.0+

### DIFF
--- a/DNSDist.py
+++ b/DNSDist.py
@@ -12,7 +12,7 @@ except ImportError:
 
 
 class Console(object):
-    def __init__(self, key=None, host='127.0.0.1', port=5199, have_sodium=HAVE_SODIUM, merge_nonces=True):
+    def __init__(self, key=None, host='127.0.0.1', port=5199, have_sodium=HAVE_SODIUM, merge_nonces=False):
         if have_sodium:
             if key:
                 key = base64.b64decode(key)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Python library to talk to [dnsdist](http://dnsdist.org)
 
 Since version 1.2.0, dnsdist uses merged nonces to send and receive messages, while pre 1.2.0 dnsdist does not.
 
-By default, this library will use merged nonces. To disable, set the merge\_nonces argument to False.
+The default is to use the pre-1.2.0 behaviour. To enable, set the merge\_nonces argument to True.
 
 ## Requirements
 
@@ -26,7 +26,7 @@ print console.execute('showServers()')
 from DNSDist import Console
 
 # Connect to dnsdist 1.2.0+ instance on 10.100.1.2:3200 with supplied key
-console = Console(key='tZ+bElqKb+moWK1BAAlSjIjAdVb9zTXT7Ziqj/lw/R8=', host='10.100.1.2', port=3200)
+console = Console(key='tZ+bElqKb+moWK1BAAlSjIjAdVb9zTXT7Ziqj/lw/R8=', host='10.100.1.2', port=3200, merged_nonces=True)
 print console.execute('showServers()')
 ```
 
@@ -34,7 +34,7 @@ print console.execute('showServers()')
 from DNSDist import Console
 
 # Connect to dnsdist pre 1.2.0 instance on 10.100.1.2:3200 with supplied key
-console = Console(key='tZ+bElqKb+moWK1BAAlSjIjAdVb9zTXT7Ziqj/lw/R8=', host='10.100.1.2', port=3200, merge_nonces=False)
+console = Console(key='tZ+bElqKb+moWK1BAAlSjIjAdVb9zTXT7Ziqj/lw/R8=', host='10.100.1.2', port=3200)
 print console.execute('showServers()')
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # python-dnsdist
 Python library to talk to [dnsdist](http://dnsdist.org)
 
+Since version 1.2.0, dnsdist uses merged nonces to send and receive messages, while pre 1.2.0 dnsdist does not.
+
+By default, this library will use merged nonces. To disable, set the merge\_nonces argument to False.
+
 ## Requirements
 
 * [libnacl](https://libnacl.readthedocs.org/) is required if you need to talk to a dnsdist instance that is compiled with libsodium support
@@ -21,8 +25,16 @@ print console.execute('showServers()')
 ```python
 from DNSDist import Console
 
-# Connect to dnsdist instance on 10.100.1.2:3200 with supplied key
+# Connect to dnsdist 1.2.0+ instance on 10.100.1.2:3200 with supplied key
 console = Console(key='tZ+bElqKb+moWK1BAAlSjIjAdVb9zTXT7Ziqj/lw/R8=', host='10.100.1.2', port=3200)
+print console.execute('showServers()')
+```
+
+```python
+from DNSDist import Console
+
+# Connect to dnsdist pre 1.2.0 instance on 10.100.1.2:3200 with supplied key
+console = Console(key='tZ+bElqKb+moWK1BAAlSjIjAdVb9zTXT7Ziqj/lw/R8=', host='10.100.1.2', port=3200, merge_nonces=False)
 print console.execute('showServers()')
 ```
 


### PR DESCRIPTION
Since version 1.2.0, dnsdist uses merged nonces to send/receive
messages.

https://github.com/PowerDNS/pdns/pull/4815